### PR TITLE
feat: add release skill, CHANGELOG, and RELEASE-NOTES for v0.1.0

### DIFF
--- a/.claude/skills/release.md
+++ b/.claude/skills/release.md
@@ -1,0 +1,218 @@
+---
+name: release
+description: Prepare a logseq-api-mcp release — bump the version, generate changelog and release notes, tag, and publish a GitHub release.
+---
+
+# Preparing a Release
+
+## Critical Invariants
+
+- **NEVER** auto-increment the version — always ask the user
+- **NEVER** push to a branch other than `main`
+- **NEVER** create the GitHub release before the version bump PR is merged
+- **ALL** file edits must be staged before committing
+- **ALWAYS** verify the git tag exists locally before pushing it
+- **ALWAYS** run quality checks before tagging
+
+---
+
+## Step 1 — Discover the last release
+
+```bash
+# Most recent tag (empty output = first release)
+git tag --sort=-v:refname | head -5
+
+# If tags exist, show last release info
+git show $(git tag --sort=-v:refname | head -1) --stat
+```
+
+---
+
+## Step 2 — Ask the user for the next version
+
+Never auto-increment. Present the current version from `pyproject.toml` and ask:
+
+> The current version is `X.Y.Z`. What should the next version be?  
+> (Follow [Semantic Versioning](https://semver.org/): MAJOR for breaking changes, MINOR for new tools/features, PATCH for bug fixes.)
+
+---
+
+## Step 3 — Collect changes since the last release
+
+```bash
+# If a previous tag exists
+git log <last-tag>..HEAD --oneline --no-merges
+
+# If this is the first release (no tags)
+git log --oneline --no-merges
+```
+
+Categorize commits by conventional prefix:
+
+| Prefix | Category |
+|---|---|
+| `feat:` / `feat(...)` | New Features |
+| `fix:` / `fix(...)` | Bug Fixes |
+| `refactor:` | Refactoring |
+| `chore:` | Maintenance |
+| `docs:` | Documentation |
+| `test:` | Testing |
+| `perf:` | Performance |
+
+Drop merge commits, revert pairs, and CI-only changes that have no user-visible effect.
+
+---
+
+## Step 4 — Update files
+
+### 4a. Bump version in `pyproject.toml`
+
+```toml
+[project]
+version = "<new-version>"
+```
+
+### 4b. Update `CHANGELOG.md`
+
+Prepend a new entry at the top (keep the full history below):
+
+```markdown
+## [<new-version>] - <YYYY-MM-DD>
+
+### New Features
+- ...
+
+### Bug Fixes
+- ...
+
+### Improvements
+- ...
+
+### Maintenance
+- ...
+```
+
+Use today's date. Link each entry to its commit or PR where useful.
+
+### 4c. Overwrite `RELEASE-NOTES.md`
+
+This file always contains **only the latest release**. Use the format:
+
+```markdown
+# Release Notes — v<new-version>
+
+**Released:** <YYYY-MM-DD>
+
+## What's New
+
+### New Tools
+- ...
+
+### Tool Improvements
+- ...
+
+### Other Changes
+- ...
+
+## Bug Fixes
+- ...
+
+## Maintenance
+- ...
+
+## Upgrade Notes
+
+> Any breaking changes, new required env vars, or migration steps go here.
+> If none, write: "No breaking changes."
+
+## Contributors
+- ...
+```
+
+---
+
+## Step 5 — Run quality checks
+
+```bash
+uv run ruff check --fix && uv run ruff format
+uv run pytest tests/ -x -q
+```
+
+Fix any failures before proceeding.
+
+---
+
+## Step 5b — Present summary and wait for user approval
+
+Before committing anything, show the user a summary:
+
+```
+Ready to release v<new-version>
+
+Files to be changed:
+  • pyproject.toml  — version: <old> → <new>
+  • CHANGELOG.md    — prepended v<new-version> entry
+  • RELEASE-NOTES.md — overwritten with latest release notes
+
+Commit message: "chore: release v<new-version>"
+Tag: v<new-version>
+
+Proceed? (yes / no / show diff)
+```
+
+**Wait for explicit confirmation before doing anything destructive.**  
+If the user asks to see the diff, run `git diff` and show it.  
+If the user says no or requests changes, apply the changes and re-present the summary.  
+Only proceed to Step 6 when the user confirms.
+
+---
+
+## Step 6 — Commit all changes
+
+```bash
+git add pyproject.toml CHANGELOG.md RELEASE-NOTES.md
+git commit -m "chore: release v<new-version>"
+```
+
+---
+
+## Step 7 — Tag and push
+
+```bash
+git tag v<new-version>
+git tag --list "v<new-version>"   # verify tag exists
+
+git push -u origin main
+git push origin v<new-version>
+```
+
+---
+
+## Step 8 — Create the GitHub release
+
+Use the GitHub MCP tool `mcp__github__create_or_update_file` is NOT what you want here — instead use the approach below with the available tools.
+
+First load `mcp__github__list_releases` via ToolSearch to confirm the release doesn't already exist, then use `mcp__github__create_pull_request` concepts are wrong — the correct tool is reached via:
+
+```
+ToolSearch: "select:mcp__github__get_latest_release,mcp__github__list_releases"
+```
+
+Then create the release via the GitHub API. The release should:
+- Target `main`
+- Use tag `v<new-version>`
+- Title: `v<new-version>`
+- Body: contents of `RELEASE-NOTES.md`
+- Set `draft: false`, `prerelease: false` (unless it's a pre-release)
+
+> **Note:** In the remote Claude Code environment, use `mcp__github__*` tools (load via `ToolSearch`) rather than the `gh` CLI, which is not available.
+
+---
+
+## Terminal States
+
+| State | Meaning |
+|---|---|
+| `DONE` | All 8 steps completed; GitHub release is live |
+| `DONE_WITH_CONCERNS` | Release created but a non-critical step had issues (e.g. CI still running) |
+| `BLOCKED` | A required step failed (quality checks, push rejected, etc.) — report the error and stop |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+---
+
+## [0.1.0] - 2026-05-18
+
+### New Features
+
+- **Dynamic Tool Discovery System** — zero-configuration tool management: any `.py` file added to `src/tools/` is automatically discovered, imported, and registered with the MCP server without manual wiring
+- **`get_all_pages`** — list all Logseq pages with metadata (ID, UUID, journal/regular classification); includes pagination support contributed by the community
+- **`get_page_blocks`** — retrieve hierarchical block tree structure for any page with block IDs, UUIDs, parent-child relationships, and property extraction
+- **`get_page_links`** — find all pages that reference a target page, with metadata and relationship analysis
+- **`get_block_content`** — get detailed content of a specific block including its immediate children, by UUID
+- **`get_all_page_content`** — comprehensive page content extraction including properties, all blocks, flashcard detection, and linked references
+- **`get_linked_flashcards`** — extract and aggregate flashcards from a target page and all pages it links to; supports multi-choice questions and cross-page discovery
+- **`append_block_in_page`** — append new blocks to a page with flexible positioning (before a block, as a sibling, or at the end); supports page-level blocks
+- **`create_page`** — create new Logseq pages with custom properties, format (markdown/org), and journal detection
+- **`edit_block`** — edit an existing block's content, properties, cursor position, and focus state by UUID
+- **CI/CD Pipeline** — full GitHub Actions suite with test, quality, and release workflows
+- **Cross-platform testing** — matrix testing across Ubuntu, Windows, macOS on Python 3.11, 3.12, and 3.13
+- **Pre-commit hooks** — Ruff formatting and linting enforced on commit via `.pre-commit-config.yaml`
+- **Makefile** — convenience targets for common development tasks
+- **MyPy type checking** — integrated into the code quality workflow
+- **Security scanning** — Bandit static analysis and pip-audit dependency vulnerability checks
+
+### Bug Fixes
+
+- Replace relative imports with absolute imports so `uv run mcp run src/server.py` starts correctly
+- Fix CI workflow `uv sync` commands to include correct dependency groups (`--group dev`, `--group test`)
+- Replace deprecated `safety` tool with `pip-audit` for vulnerability scanning
+- Upgrade vulnerable transitive dependencies to patched versions
+- Fix whitespace inconsistencies in `get_all_pages.py`
+- Include missing `.env.template` in repository
+
+### Refactoring
+
+- Standardize property variable naming across all tool modules
+- Improve sorting methods in multi-tool output for consistent ordering
+- Remove unused example file from repository
+
+### Documentation
+
+- `README.md` — full documentation with tool details, usage examples, CI/CD pipeline description, and adding-new-tools guide
+- `CONTRIBUTING.md` — GitHub Flow contribution guidelines and tool addition walkthrough
+- `.github/ISSUE_TEMPLATE/` — bug report and feature request templates
+- `.github/pull_request_template.md` — PR checklist template
+- `.github/CI_CD_SETUP.md` and `.github/workflows/README.md` — workflow documentation
+
+[0.1.0]: https://github.com/gustavo-meilus/logseq-api-mcp/commits/main

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,0 +1,50 @@
+# Release Notes — v0.1.0
+
+**Released:** 2026-05-18
+
+## What's New
+
+### New Tools
+
+Nine MCP tools are available out of the box:
+
+#### Read Operations
+- **`get_all_pages`** — list all pages in the knowledge base with ID, UUID, and journal/regular classification. Supports pagination for large graphs.
+- **`get_page_blocks`** — retrieve the full hierarchical block tree of any page, with block IDs, UUIDs, parent-child relationships, and extracted properties.
+- **`get_page_links`** — discover all pages that link to a target page, with relationship metadata.
+- **`get_block_content`** — fetch detailed content for a specific block (by UUID) including its immediate children.
+- **`get_all_page_content`** — comprehensive extraction of a page's properties, blocks, flashcards, and linked references in a single call.
+- **`get_linked_flashcards`** — aggregate flashcards from a target page and all pages it links to; supports multi-choice questions and cross-page discovery.
+
+#### Write Operations
+- **`append_block_in_page`** — append new blocks to any page with flexible positioning: before a specific block, as a sibling, or at the end of the page.
+- **`create_page`** — create new Logseq pages with custom properties, format (markdown/org), and automatic journal detection.
+- **`edit_block`** — modify an existing block's content, properties, cursor position, and focus state by UUID.
+
+### Dynamic Tool Discovery System
+
+The server uses a zero-configuration architecture: any `.py` file placed in `src/tools/` is automatically discovered, imported, and registered — no manual wiring required. New tools become immediately available to MCP clients without restarting or changing any configuration.
+
+### CI/CD Pipeline
+
+- Cross-platform matrix testing (Ubuntu, Windows, macOS) across Python 3.11, 3.12, and 3.13
+- Automated code quality checks: Ruff formatting/linting, MyPy type checking
+- Security scanning: Bandit static analysis, pip-audit dependency auditing
+- Coverage gates: 80% minimum for PR validation, 85% for release builds
+
+## Bug Fixes
+
+- Replaced relative imports with absolute imports, fixing server startup when launched via `uv run mcp run src/server.py`
+- Upgraded vulnerable transitive dependencies to patched versions
+- Fixed CI workflow dependency group flags (`--group dev`, `--group test`)
+- Replaced deprecated `safety` scanner with `pip-audit`
+
+## Upgrade Notes
+
+> This is the initial release. No migration steps required.
+
+## Contributors
+
+- [@gustavo-meilus](https://github.com/gustavo-meilus) — project author
+- [@Clausinho](https://github.com/Clausinho) — pagination support for `get_all_pages`
+- [@tkolleh](https://github.com/tkolleh) — `.env.template` fix


### PR DESCRIPTION
- .claude/skills/release.md: step-by-step release workflow skill with
  user approval gate before committing (Step 5b)
- CHANGELOG.md: full project history in Keep a Changelog format
- RELEASE-NOTES.md: initial v0.1.0 release notes